### PR TITLE
Suppression urls non déréférençables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,10 @@ RUN curl -F inputShapeFile=@profil-application/rdafr-shacl.ttl \
          -H 'Accept-Language: fr-FR,fr' \
          https://shacl-play.sparna.fr/play/doc \
          > /usr/share/nginx/html/profil-application/index.html
+
+# Suppression des URLs non déréférençables
+RUN sed -i -E 's/<a href="(https:\/\/rdafr\.fr\/Elements\/.*?\/)" target="_blank">.*?<\/a>/\1/;s/<a href="https:\/\/rdafr\.fr\/(Elements|termList)\/.*?>(.*?)<\/a>/\2/' /usr/share/nginx/html/profil-application/index.html
+
 #COPY ./ontologie/ /usr/share/nginx/html/ontologie/
 # todo : ajouter ici la convertion en HTML du OWL
 COPY ./vocabulaire/ /usr/share/nginx/html/vocabulaire/

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,9 @@ RUN curl -F inputShapeFile=@profil-application/rdafr-shacl.ttl \
          > /usr/share/nginx/html/profil-application/index.html
 
 # Suppression des URLs non déréférençables
-RUN sed -i -E 's/<a href="(https:\/\/rdafr\.fr\/Elements\/.*?\/)" target="_blank">.*?<\/a>/\1/;s/<a href="https:\/\/rdafr\.fr\/(Elements|termList)\/.*?>(.*?)<\/a>/\2/' /usr/share/nginx/html/profil-application/index.html
+RUN sed -E -i /usr/share/nginx/html/profil-application/index.html \
+    -e 's#<a href="(https://rdafr\.fr/Elements/.*?/)" target="_blank">.*?</a>#\1#' \
+    -e 's#<a href="https://rdafr\.fr/(Elements|termList)/.*?>(.*?)</a>#\2#'
 
 #COPY ./ontologie/ /usr/share/nginx/html/ontologie/
 # todo : ajouter ici la convertion en HTML du OWL


### PR DESCRIPTION
Cette PR supprime les URLs qui génèrent des erreurs 404 dans le profil d'application.

Côté SED j'ai fait le choix de chainer deux patterns avec `;` plutôt que d'avoir une seule expression régulière trop complexe.

1.  `s/<a href="(https:\/\/rdafr\.fr\/Elements\/.*?\/)" target="_blank">.*?<\/a>/\1/`
2. `s/<a href="https:\/\/rdafr\.fr\/(Elements|termList)\/.*?>(.*?)<\/a>/\2/`

Dans le premier cas on récupère  et on affiche le contenu de l'attribut href dans la documentation. Dans le second cas on récupère et on affiche la valeur littérale de la balise `<a>` (par exemple pour les termList).

Pour la réécriture du HTML j'ai rajouté une nouvelle entrée RUN dans le Dockerfile pour identifier clairement la "fonctionnalité".

@kerphi J'ai testé la substitution en local à partir du HTML de [test.rda.fr/profil](https://test.rdafr.fr/profil-application/), en revanche je n'ai pas testé la partie Docker.