### PR TITLE
Refactorisation de la génération des contenus HTML

### DIFF
--- a/.github/workflows/build-test-pubtodockerhub.yml
+++ b/.github/workflows/build-test-pubtodockerhub.yml
@@ -15,13 +15,22 @@ on:
 
 
 jobs:
+  prepare-release:
+    uses: ./.github/workflows/prepare-release.yml
+
   build-test-pubtodockerhub:
+    needs: prepare-release 
     runs-on: ubuntu-latest
     steps:
-
-
       - name: "Build: checkout source code"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+      
+      - name: "Récupération du build"
+        uses: actions/download-artifact@v3
+        with:
+          name: build
+          path: build
+
       - name: "Build: build the docker image for rdafr.fr website"
         run: |
           docker build . -t localimage:latest

--- a/.github/workflows/google-sheet-to-ttl.yml
+++ b/.github/workflows/google-sheet-to-ttl.yml
@@ -13,7 +13,7 @@ jobs:
           -H "Connection: keep-alive" \
           -F url='https://docs.google.com/spreadsheets/d/1CZIf3bxuuH3aghFn7B7P89DrLqp_jzv4moI_BpI9PzY/export?format=xlsx' \
           -F format=ttl \
-          -o ./profil-application/rdafr-schacl.ttl
+          -o ./profil-application/rdafr-shacl.ttl
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "Feat : Mise à jour de l'ontologie"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,125 @@
+# Prépare la release de l'ontologie sur le site rdafr.fr
+name: "Prepare Release"
+on:
+  workflow_call:
+
+jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      # Le répertoire de sortie a l'arborescence suivante :
+      #
+      # release/
+      #  ├─ ontologie/             -->  /usr/share/nginx/html/ontologie/
+      #  │  ├─ index.html
+      #  |  └─ ..
+      #  ├─ profil-application/    --> /usr/share/nginx/html/profil-application/
+      #  |  └─ index.html
+      #  └─ siteweb/               --> /usr/share/nginx/html/
+      #     ├─ index.html
+      #     ├─ style.css
+      #     └─ ...
+      - name: "Création des répertoires de sortie"
+        run: |
+          mkdir build
+          mkdir build/siteweb
+          mkdir build/ontologie
+          mkdir build/profil-application
+
+      - name: "Installation des locales FR"
+        run: |
+          apt update && apt -y install locales
+          sed -i '/fr_FR.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
+          export LANG=fr_FR.UTF-8
+          export LANGUAGE=fr_FR:fr
+          export LC_ALL=fr_FR.UTF-8
+
+
+      # Site web
+      - name: "Installation de Pandoc"
+        # On utilise le tarball de pandoc plutôt qu'apt pour avoir une version 3.x qui supporte l'option shift-heading-level-by
+        run: |
+          curl -L https://github.com/jgm/pandoc/releases/download/3.1.2/pandoc-3.1.2-1-amd64.deb -o pandoc.deb
+          sudo dpkg -i pandoc.deb
+
+      - name: "Génération du site Web"
+        run: |
+          cp ./siteweb/.docker/* ./build/siteweb/
+          sed -i "s#LAST_MODIFICATION_DATE_PLACEHOLDER#$(date +'%e %B %Y')#g" ./build/siteweb/footer.html
+          pandoc ./siteweb/01_INTRO.md -o ./build/siteweb/intro.html
+          pandoc --standalone \
+            --toc \
+            --shift-heading-level-by=-1 \
+            --template ./build/siteweb/template.html \
+            -c style.css \
+            -B ./build/siteweb/intro.html \
+            -A ./build/siteweb/footer.html \
+            ./siteweb/02_CONTENT.md -o ./build/siteweb/index.html
+
+      - name: "Génération des release notes"
+        run: |
+          pandoc --standalone \
+            --toc \
+            --shift-heading-level-by=-1 \
+            --template ./build/siteweb/template.html \
+            -c style.css \
+            ./siteweb/release-notes.md -o ./build/siteweb/release-notes.html
+
+
+      # Ontologie
+      - name: "Installation de java"
+        uses: actions/setup-java@v1
+        with:
+          java-version: "17"
+
+      - name: "Installation de Widoco"
+        run: |
+          curl -L https://github.com/dgarijo/Widoco/releases/download/v1.4.17/java-17-widoco-1.4.17-jar-with-dependencies.jar -o widoco.jar
+      
+      # On récupère l'ontologie au format nt plutôt que ttl pour faciliter les modifications avec SED
+      - name: "Récupération de l'ontologie au format nt"
+        run : |
+          curl -L --request GET 'https://xls2rdf.sparna.fr/rest/convert?noPostProcessings=true' \
+            -H "Connection: keep-alive" \
+            -F url='https://docs.google.com/spreadsheets/d/1CZIf3bxuuH3aghFn7B7P89DrLqp_jzv4moI_BpI9PzY/export?format=xlsx' \
+            -F format=text/plain \
+            -o ./build/rdafr.nt
+
+      # Enlève les noeuds vides et les éléments shacl qui sont problématiques pour Widoco
+      - name: "Pré traitement de l'ontologie"
+        run: |
+          sed -e "#http://www.w3.org/ns/shacl#d" -e "/_:node/d" -i ./build/rdafr.nt  
+
+      - name: "Génération de la documentation"
+        run: |
+          java -jar widoco.jar -ontFile ./build/rdafr.nt -outFolder ./build/ontologie -rewriteAll -lang fr -excludeIntroduction -includeAnnotationProperties -noPlaceHolderText -webVowl
+          mv ./build/ontologie/index-fr.html ./build/ontologie/index.html
+          rm build/rdafr.nt
+
+
+      # Profil d'application
+      - name: "Génération du profil d'application"
+        run: |
+          curl -F inputShapeFile=@profil-application/rdafr-shacl.ttl \
+            -F shapesSource=file \
+            -F language=fr \
+            -H 'Accept-Language: fr-FR,fr' \
+            https://shacl-play.sparna.fr/play/doc \
+            > ./build/profil-application/index.html
+
+      # Retire les URLs 404
+      - name: "Post traitement du profil d'application"
+        run: |
+          sed -E -i ./build/profil-application/index.html \
+            -e 's#<a href="(https://rdafr\.fr/Elements/.*?/)" target="_blank">.*?</a>#\1#' \
+            -e 's#<a href="https://rdafr\.fr/(Elements|termList)/.*?>(.*?)</a>#\2#'
+
+            
+      - name: "Sauvergarde du build"
+        uses: actions/upload-artifact@v3
+        with:
+          name: build
+          path: build
+          retention-days: 1

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -117,7 +117,7 @@ jobs:
             -e 's#<a href="https://rdafr\.fr/(Elements|termList)/.*?>(.*?)</a>#\2#'
 
             
-      - name: "Sauvergarde du build"
+      - name: "Sauvegarde du build"
         uses: actions/upload-artifact@v3
         with:
           name: build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,57 +1,12 @@
 FROM nginx:1.20.2
 ENV ONTOLOGIE_RDAFR_VERSION 0.3.5
 
-# Installation et configuration de la locale FR
-# pour avoir les dates auto-générées du footer.html en français
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt -y install locales
-RUN sed -i '/fr_FR.UTF-8/s/^# //g' /etc/locale.gen && \
-    locale-gen
-ENV LANG fr_FR.UTF-8
-ENV LANGUAGE fr_FR:fr
-ENV LC_ALL fr_FR.UTF-8
-
-
-# Compilation du siteweb en partant des markdown
-# 01_INTRO.md et 02_CONTENT.md
-# pour générer la page HTML de https://rdafr.fr
-# en utilisant l'outil pandoc https://pandoc.org/
-RUN DEBIAN_FRONTEND=noninteractive apt install -y pandoc
-COPY ./siteweb/*   /usr/share/nginx/html/
-COPY ./siteweb/.docker/*   /usr/share/nginx/html/
-RUN sed -i "s#LAST_MODIFICATION_DATE_PLACEHOLDER#$(date +'%e %B %Y')#g" /usr/share/nginx/html/footer.html
-WORKDIR /usr/share/nginx/html/
-RUN pandoc 01_INTRO.md -o intro.html
-RUN pandoc --standalone \
-      --toc \
-      --shift-heading-level-by=-1 \
-	  --template template.html \
-      -c style.css \
-      -B intro.html \
-      -A footer.html \
-      02_CONTENT.md -o ./index.html
-
-
-# Compilation des SHACL .ttl en HTML en utilisant
-# l'outil https://shacl-play.sparna.fr/play/doc
-RUN DEBIAN_FRONTEND=noninteractive apt install -y curl
-COPY ./profil-application/ /usr/share/nginx/html/profil-application/
-RUN curl -F inputShapeFile=@profil-application/rdafr-shacl.ttl \
-         -F shapesSource=file \
-         -F language=fr \
-         -H 'Accept-Language: fr-FR,fr' \
-         https://shacl-play.sparna.fr/play/doc \
-         > /usr/share/nginx/html/profil-application/index.html
-
-# Suppression des URLs non déréférençables
-RUN sed -E -i /usr/share/nginx/html/profil-application/index.html \
-    -e 's#<a href="(https://rdafr\.fr/Elements/.*?/)" target="_blank">.*?</a>#\1#' \
-    -e 's#<a href="https://rdafr\.fr/(Elements|termList)/.*?>(.*?)</a>#\2#'
-
-#COPY ./ontologie/ /usr/share/nginx/html/ontologie/
-# todo : ajouter ici la convertion en HTML du OWL
+COPY ./build/siteweb/* /usr/share/nginx/html/
+COPY ./build/profil-application/ /usr/share/nginx/html/profil-application/
+COPY ./build/ontologie/ /usr/share/nginx/html/ontologie/
 COPY ./vocabulaire/ /usr/share/nginx/html/vocabulaire/
-# todo : ajouter la convertion en HTML des vocabulaires
 
+# todo : ajouter la convertion en HTML des vocabulaires
 
 # Lance le serveur web
 CMD ["nginx", "-g", "daemon off;"]

--- a/siteweb/01_INTRO.md
+++ b/siteweb/01_INTRO.md
@@ -1,17 +1,17 @@
 # Ontologie RDA-FR
 
-Ce site est dédié à la publication de l’ontologie RDA-FR qui est en cours d’élaboration. 
+**Version bêta partielle v.0.1.0**
 
-Le domaine de l’ontologie RDA-FR est **https://rdafr.fr**
+Ce site est dédié à la publication de l’ontologie RDA-FR qui est en cours d’élaboration.
 
-**Le profil d'application de l'ontologie RDA-FR est publié ici : [https://rdafr.fr/profil-application/](/profil-application/) (version 0.0.1 beta, partielle)**
+Le domaine de l’ontologie RDA-FR est **[https://rdafr.fr](https://rdafr.fr)**
+
+**Le profil d’application de l’ontologie RDA-FR est publié ici : [https://rdafr.fr/profil-application/](https://rdafr.fr/profil-application/)**
+
+**L’ontologie RDA-FR en OWL est publié ici : [mettre lien]**
 
 Dans le cadre du programme [Transition bibliographique](https://www.transition-bibliographique.fr/), l’objectif de l’ontologie RDA-FR est d’exprimer avec les technologies du web sémantique les entités, leurs attributs et leurs relations définies par le [code de catalogage RDA-FR](https://www.transition-bibliographique.fr/rda-fr/) en conformité avec le modèle international [IFLA LRM](https://www.transition-bibliographique.fr/enjeux/definition-ifla-lrm/).
 
 L’ontologie RDA-FR permettra aux agences bibliographiques nationales et aux éditeurs de SGB (systèmes de gestion de bibliothèques) de créer ou de diffuser dans un environnement web sémantique des données structurées conformément à ce code. L’enjeu est d’assurer la visibilité des données produites selon le code RDA-FR dans le web de données et de faciliter leur exploitation par tous, au-delà des bibliothèques.
 
-Sa première utilisation nationale se fera dans le cadre du [Fichier national d'entités (FNE)](https://www.transition-bibliographique.fr/fne/fichier-national-entites/).
-
 Les deux agences bibliographiques, la BnF et l’Abes, ont fait le choix de publier l’ontologie RDA-FR progressivement, par blocs de classes cohérents, au fur et à mesure de son élaboration.
-
-Aussi vous trouverez ci-dessous la publication de la v0.0.1 de cette ontologie.

--- a/siteweb/02_CONTENT.md
+++ b/siteweb/02_CONTENT.md
@@ -11,8 +11,7 @@ L’ontologie RDA-FR, en cours d’élaboration, est une représentation formell
 
 Le schéma suivant donne une vue globale de la hiérarchie des classes de l’ontologie RDA-FR. Seules sont traitées dans cette version bêta les classes non grisées ci-dessous.
 
-
-![alt_text](images/image1.jpg "image_tooltip")
+![image](https://user-images.githubusercontent.com/60341438/235084770-494c5256-ef7a-4de4-a707-0b3a934e6b4d.png)
 
 ## Domaine de l’ontologie RDA-FR et espaces de noms
 
@@ -38,7 +37,7 @@ Dans le système des classes et propriétés :
 * La classe **_Identité publique_**, spécifique à l’ontologie RDA-FR, reflète l’approche du chapitre 9 du code RDA-FR Identification des personnes et de leurs identités publiques, où la distinction claire entre les personnes et leurs identités publiques est actée. Une personne ou un groupe informel a toujours au moins une identité publique. Le modèle IFLA LRM appréhende l’Identité publique comme une grappe de Nomen (voir [IFLA LRM, 2017, traduction française](https://repository.ifla.org/bitstream/123456789/1703/1/IFLA-LRM-traduction-francaise.pdf), paragraphe 5.5 Modélisation des identités bibliographiques). Dans l’ontologie RDA-FR, la classe Identité publique est déclarée comme une sous-classe de la classe racine ‘Entité RDA-FR’. \
 Pour les relations entre la classe Identité publique et les classes Personne ou Groupe informel, ainsi que les relations de ces dernières avec la classe Oeuvre, voir le schéma ci-dessous :
 
-![alt_text](images/image2.jpg "image_tooltip")
+![image](https://user-images.githubusercontent.com/60341438/235084868-330a960e-a311-445d-89f8-8263fce722ba.png)
 
 * Les classes **_Lieu_** et **_Laps de temps_** (entités du modèle IFLA LRM), les classes **_Concept_**, **_Objet_**, **_Événement_**, ainsi que les sous-classes de Lieu et de Laps de temps, sont d’ores et déjà créées dans l’ontologie RDA-FR pour leur réserver la place qui convient dans l’architecture globale. Elles seront abordées en détail, ou modifiées, lorsque les chapitres correspondants ou les orientations normatives du code RDA-FR seront publiés, sous réserve de l’avancée des travaux des groupes nationaux de la Transition Bibliographique.
 
@@ -57,13 +56,13 @@ Pour les relations entre la classe Identité publique et les classes Personne ou
 * la classe P100008 **_‘a une propriété réifiée’_** a été introduite pour permettre d’ajouter des assertions sur toutes les propriétés de l’ontologie qui correspondent aux attributs des entités du code RDA-FR. Par exemple, il est possible d’indiquer un niveau de fiabilité, ou une source pour un lieu de naissance d’une personne. Elle permet aussi de donner, à la propriété en question, une valeur textuelle ou une URI. Chaque propriété de ce type est systématiquement réifiée par une classe dont l’URI est la même que celle de la propriété. Cette classe est déclarée comme une sous classe de la classe P100008 _‘a une propriété réifiée’_ :
 
 Exemple de réification de l’attribut _“a pour lieu de naissance de la personne”_ 
-![alt_text](images/image3.jpg "image_tooltip")
+![image](https://user-images.githubusercontent.com/60341438/235085011-71a40ad8-f8e6-4b86-8387-995b06a51a2b.png)
 
 * la classe P100001r **_‘a une relation avec [dans la relation]’_** a été introduite pour permettre d’ajouter des assertions sur toutes les propriétés qui expriment une relation entre des instances de deux classes de l’ontologie (et qui, de fait, correspondent aux relations entre instances d’entités du code RDA-FR). Elle permet par exemple de donner des précisions (source, période, etc.) sur une relation de type _“a pour créateur / créateur de”_ entre une oeuvre et une personne. Chaque propriété de ce type est systématiquement réifiée par une classe dont l’URI est la même que celle de la propriété. Cette classe est déclarée comme une sous classe de la classe P100001r _‘a une relation avec [dans la relation]’_. \
 Font exception de cette règle les relations dites fondamentales du modèle IFLA LRM entre les classes Oeuvre, Expression, Manifestation et Item.
 
 Exemple de réification de la relation _“a pour créateur / créateur de”_ 
-![alt_text](images/image4.jpg "image_tooltip")
+![image](https://user-images.githubusercontent.com/60341438/235085174-d8869b2c-9245-4265-bd72-09793a4b83de.png)
 
 **Principe de déclaration des propriétés, dites génériques, applicables à plusieurs entités**
 

--- a/siteweb/02_CONTENT.md
+++ b/siteweb/02_CONTENT.md
@@ -3,91 +3,119 @@ pagetitle: Ontologie RDA-FR
 toc-title: Table des matières
 ---
 
-### Première publication de l’ontologie RDA-FR : version 0.0.1 beta, partielle
+# **Introduction : architecture et choix de conception**
 
-#### Introduction
-L’ontologie RDA-FR, en cours d’élaboration, est une représentation formelle du code RDA-FR, sous forme d'une ontologie OWL.
+L’ontologie RDA-FR, en cours d’élaboration, est une représentation formelle du code RDA-FR, sous forme d’une ontologie OWL.
 
-Cette première publication est une version beta, partielle. Elle concerne la partie de l’ontologie RDA-FR relative aux classes : Agent, Agent collectif, Groupe informel, Personne, Identité publique.
-
-**Avertissement** : tout au cours du processus d’élaboration, la version publiée est susceptible d'évoluer (par des compléments ou des corrections) en fonction des décisions du groupe de travail. Ces évolutions seront documentées au fil des publications.
+**Avertissement** : tout au long du processus d’élaboration, la version publiée est susceptible d’évoluer (par des compléments ou des corrections) en fonction des décisions du groupe de travail. Ces évolutions seront documentées au fil des publications.
 
 Le schéma suivant donne une vue globale de la hiérarchie des classes de l’ontologie RDA-FR. Seules sont traitées dans cette version bêta les classes non grisées ci-dessous.
 
-![](https://user-images.githubusercontent.com/51800062/215845393-ead4cc13-63bf-4763-a791-d5f714f5579b.jpg)
 
-#### Architecture et choix de conception
+![alt_text](images/image1.jpg "image_tooltip")
 
-##### Domaine de l’ontologie RDA-FR et espaces de noms
+## Domaine de l’ontologie RDA-FR et espaces de noms
 
-Pour des besoins de clarté, toutes les classes, propriétés et vocabulaires de l’ontologie RDA-FR sont déclarées dans l’espace de nom https://rdafr.fr, avec des URIs qui leurs sont propres, sans reprise directe ni réutilisation des URIs des classes ou des propriétés d’une autre ontologie existante. 
+Pour des besoins de clarté, toutes les classes, propriétés et vocabulaires de l’ontologie RDA-FR sont déclarées dans l’espace de nom https://rdafr.fr, avec des URIs qui leurs sont propres, sans reprise directe ni réutilisation des URIs des classes ou des propriétés d’une autre ontologie existante.
 
-Il est, pourtant, prévu d’établir des alignements avec les autres ontologies pour pouvoir dialoguer avec d’autres acteurs du secteur des bibliothèques et ceux d’autres secteurs. En premier lieu, des alignements seront déclarés avec l’[ontologie IFLA LRM](https://www.iflastandards.info/lrm), avec laquelle l’ontologie RDA-FR est en cohérence, comme l’est l’[ontologie RDA](https://www.rdaregistry.info/).
+Il est pourtant prévu d’établir des alignements avec les autres ontologies pour pouvoir dialoguer avec d’autres acteurs du secteur des bibliothèques et ceux d’autres secteurs. En premier lieu, des alignements seront déclarés avec l’[ontologie IFLA LRM](https://www.iflastandards.info/lrm), avec laquelle l’ontologie RDA-FR est en cohérence, comme l’est l’[ontologie RDA](https://www.rdaregistry.info/).
 
-##### Le code RDA-FR, le modèle IFLA LRM et l’ontologie RDA-FR - classes et propriétés de l’univers bibliographique
 
-Dans le système des classes et propriétés :
-- Pour chacune des entités du code RDA-FR on trouve la classe correspondante dans l’ontologie RDA-FR (classes Œuvre, Personne, etc.). Ces classes sont organisées selon la même hiérarchie que dans le code RDA-FR, en conformité avec l’ontologie IFLA LRM. A contrario, certaines classes présentes dans l’ontologie RDA-FR sont créées pour les besoins propres de celle-ci et ne se retrouvent pas dans le code RDA-FR (voir plus bas les explications sur, par exemple, la classe Groupe informel).
-- Les attributs des entités du code RDA-FR, ainsi que les relations entre entités du code constituent des propriétés dans l'ontologie RDA-FR  (« a pour langue de la personne », « est membre de » pour une relation entre une Personne et une Collectivité, etc.).
+## Le code RDA-FR, le modèle IFLA LRM et l’ontologie RDA-FR - classes et propriétés de l’univers bibliographique
 
-**Point d’attention sur la version 0.0.1**
+Dans le système des classes et propriétés : 
 
-La liste des relations entre les entités concernées par cette publication n’est pas exhaustive. Elle sera enrichie au fil des versions. Les relations présentes dans cette version permettent de montrer le mécanisme mis en œuvre pour leur expression. 
+* Pour chacune des entités du code RDA-FR, on trouve la classe correspondante dans l’ontologie RDA-FR (classes Œuvre, Personne, etc.). Ces classes sont organisées selon la même hiérarchie que dans le code RDA-FR, en conformité avec l’ontologie IFLA LRM. A contrario, certaines classes présentes dans l’ontologie RDA-FR sont créées pour les besoins propres de celle-ci et ne se retrouvent pas dans le code RDA-FR (voir plus bas les explications sur, par exemple, la classe Groupe informel). 
+* Les attributs des entités du code RDA-FR, ainsi que les relations entre entités du code constituent des propriétés dans l’ontologie RDA-FR (« a pour langue de la personne », « est membre de » pour une relation entre une Personne et une Collectivité, etc.).
 
-**Remarques générales sur les classes de l’ontologie RDA-FR**
+### Remarques générales sur les classes de l’ontologie RDA-FR
 
-- ***Entité RDA-FR*** est la classe de niveau supérieur à la racine de l’ontologie RDA-FR ; elle est déclarée comme sous-classe de la classe *Res* du modèle IFLA LRM. Toute classe de l’ontologie RDA-FR est déclarée comme sous-classe de celle-ci. Les propriétés de cette classe, en vertu du principe d’héritage, s’appliquent à toutes les sous-classes de l’ontologie. 
-- La classe ***Nomen*** (entité du modèle IFLA LRM) a été déclarée comme une classe distincte dans l’ontologie RDA-FR. Dans le code RDA-FR, il n’y a pas d’entité propre Nomen : les noms, titres d'œuvre etc., points d’accès et identifiants sont traités comme des attributs des entités qu’ils servent à identifier ou représenter. Il n’en reste pas moins que ces noms, titres, points d’accès et identifiants, du point de vue du modèle IFLA LRM, relèvent de l’entité Nomen. Ainsi, dans l’ontologie RDA-FR, toutes les propriétés qui représentent des noms, des titres, des points d’accès et des identifiants ont pour co-domaine la classe Nomen. 
-- La classe ***Agent*** (entité du modèle IFLA LRM) a été créée dans l’ontologie RDA-FR comme classe générique des sous-classes Personne et Agent collectif. Elle permet de factoriser un certain nombre de propriétés, mais aussi de traiter les cas où les informations sur la nature de l’agent sont lacunaires.
-- La classe ***Agent collectif*** (entité du modèle IFLA LRM) ne fait pas partie du code RDA-FR. Elle a aussi été ajoutée dans l’ontologie RDA-FR pour servir de super-classe aux classes Collectivité, Groupe informel (voir plus bas) et Famille. De ce fait, ces dernières héritent des propriétés de la classe Agent collectif.
-- La classe ***Groupe informel***, absente du code RDA-FR, a été créée dans l’ontologie RDA-FR comme sous-classe de la classe Agent collectif, pour permettre de traiter comme groupes du monde réel les groupes de personnes qui ne sont ni des familles ni des collectivités. C’est le cas, notamment, des groupes identifiés par un pseudonyme collectif dont le nom se présente formellement comme un nom de personne (le pseudonyme collectif, lui-même, relève de la classe Identité publique). Cette classe permet d’établir, par exemple, la relation de création entre le groupe informel et son œuvre, ou la relation entre le groupe et les personnes qui le composent.
-- La classe ***Identité publique***, spécifique à l’ontologie RDA-FR, reflète l’approche du chapitre 9 du code RDA-FR Identification des personnes et de leurs identités publiques, où la distinction claire entre les personnes et leurs identités publiques est actée. Une personne ou un groupe informel a toujours au moins une identité publique. Le modèle IFLA LRM appréhende l’Identité publique comme une grappe de Nomen (voir [IFLA LRM, 2017, traduction française](https://repository.ifla.org/bitstream/123456789/1703/1/IFLA-LRM-traduction-francaise.pdf), paragraphe 5.5 Modélisation des identités bibliographiques). Dans l’ontologie RDA-FR, la classe Identité publique est déclarée comme une sous-classe de la classe racine ‘Entité RDA-FR’. 
+* **_Entité RDA-FR_** est la classe de niveau supérieur à la racine de l’ontologie RDA-FR ; elle est déclarée comme sous-classe de la classe _Res_ du modèle IFLA LRM. Toute classe de l’ontologie RDA-FR est déclarée comme sous-classe de celle-ci. Les propriétés de cette classe, en vertu du principe d’héritage, s’appliquent à toutes les sous-classes de l’ontologie.
+* La classe **_Nomen_** (entité du modèle IFLA LRM) a été déclarée comme une classe distincte dans l’ontologie RDA-FR. Dans le code RDA-FR, il n’y a pas d’entité propre Nomen : les noms, titres d’œuvre etc., points d’accès et identifiants sont traités comme des attributs des entités qu’ils servent à identifier ou représenter. Il n’en reste pas moins que ces noms, titres, points d’accès et identifiants, du point de vue du modèle IFLA LRM, relèvent de l’entité Nomen. Ainsi, dans l’ontologie RDA-FR, toutes les propriétés qui représentent des noms, des titres, des points d’accès et des identifiants ont pour co-domaine la classe Nomen.
+* La classe **_Agent_** (entité du modèle IFLA LRM) a été créée dans l’ontologie RDA-FR comme classe générique des sous-classes Personne et Agent collectif. Elle permet de factoriser un certain nombre de propriétés, mais aussi de traiter les cas où les informations sur la nature de l’agent sont lacunaires.
+* La classe **_Agent collectif_** (entité du modèle IFLA LRM) ne fait pas partie du code RDA-FR. Elle a aussi été ajoutée dans l’ontologie RDA-FR pour servir de super-classe aux classes Collectivité, Groupe informel (voir plus bas) et Famille. De ce fait, ces dernières héritent des propriétés de la classe Agent collectif.
+* La classe **_Groupe informel_**, absente du code RDA-FR, a été créée dans l’ontologie RDA-FR comme sous-classe de la classe Agent collectif, pour permettre de traiter comme groupes du monde réel les groupes de personnes qui ne sont ni des familles ni des collectivités. C’est le cas, notamment, des groupes identifiés par un pseudonyme collectif dont le nom se présente formellement comme un nom de personne (le pseudonyme collectif, lui-même, relève de la classe Identité publique). Cette classe permet d’établir, par exemple, la relation de création entre le groupe informel et son œuvre, ou la relation entre le groupe et les personnes qui le composent.
+* La classe **_Identité publique_**, spécifique à l’ontologie RDA-FR, reflète l’approche du chapitre 9 du code RDA-FR Identification des personnes et de leurs identités publiques, où la distinction claire entre les personnes et leurs identités publiques est actée. Une personne ou un groupe informel a toujours au moins une identité publique. Le modèle IFLA LRM appréhende l’Identité publique comme une grappe de Nomen (voir [IFLA LRM, 2017, traduction française](https://repository.ifla.org/bitstream/123456789/1703/1/IFLA-LRM-traduction-francaise.pdf), paragraphe 5.5 Modélisation des identités bibliographiques). Dans l’ontologie RDA-FR, la classe Identité publique est déclarée comme une sous-classe de la classe racine ‘Entité RDA-FR’. \
+Pour les relations entre la classe Identité publique et les classes Personne ou Groupe informel, ainsi que les relations de ces dernières avec la classe Oeuvre, voir le schéma ci-dessous :
 
-  Pour les relations entre la classe Identité publique et les classes Personne ou Groupe informel, ainsi que les relations de ces dernières avec la classe Oeuvre, voir le schéma ci-dessous :
-  
-  ![](https://user-images.githubusercontent.com/51800062/215847616-c2702b44-4875-408b-bcbf-ff37b82464a9.jpg)
-  
-- Les classes ***Lieu*** et ***Laps de temps*** (entités du modèle IFLA LRM), les classes ***Concept***, ***Objet***, ***Événement***, ainsi que les sous-classes de Lieu et de Laps de temps, sont d’ores et déjà créées dans l’ontologie RDA-FR pour leur réserver la place qui convient dans l’architecture globale. Elles seront abordées en détail, ou modifiées, lorsque les chapitres correspondants ou les orientations normatives du code RDA-FR seront publiés, sous réserve de l’avancée des travaux des groupes nationaux de la Transition Bibliographique.
+![alt_text](images/image2.jpg "image_tooltip")
 
-##### Mécanismes fonctionnels de l’ontologie RDA-FR
+* Les classes **_Lieu_** et **_Laps de temps_** (entités du modèle IFLA LRM), les classes **_Concept_**, **_Objet_**, **_Événement_**, ainsi que les sous-classes de Lieu et de Laps de temps, sont d’ores et déjà créées dans l’ontologie RDA-FR pour leur réserver la place qui convient dans l’architecture globale. Elles seront abordées en détail, ou modifiées, lorsque les chapitres correspondants ou les orientations normatives du code RDA-FR seront publiés, sous réserve de l’avancée des travaux des groupes nationaux de la Transition Bibliographique.
 
-- Pour rappel, toute classe de l’ontologie RDA-FR est déclarée comme sous-classe de la classe racine ***Entité RDA-FR***. Les propriétés de cette classe, en vertu du principe d’héritage, s’appliquent à toutes les sous-classes de l’ontologie, qu’il s’agisse des classes correspondant aux entités bibliographiques, que de celles ajoutées pour les besoins fonctionnels de l’ontologie RDA-FR, ou encore des classes ajoutées pour permettre une structuration fine et précise des données.
-- Les vocabulaires contrôlés dans l’ontologie RDA-FR relèvent de la classe [***skos:ConceptScheme***](http://www.w3.org/2004/02/skos/core#ConceptScheme). Ils correspondent aux référentiels associés aux attributs des entités du code RDA-FR.
 
-  **Principe de réification**
-  
-  Pour permettre l’ajout d’assertions sur les propriétés, le mécanisme de la réification systématique des propriétés en utilisant le même URI pour la propriété et sa réification a été implémenté dans l’ontologie RDA-FR. Ce mécanisme est basé sur le standard [ETSI GS CIM 006 V1.1.1 (2019 07)](https://drive.google.com/open?id=1EH-WjUL-2vwkze3JAM9xtc_l4czbSpIN). Pour cela deux classes sont créées : 
+## Mécanismes fonctionnels de l’ontologie RDA-FR
 
-- la classe P100008 ***‘a une propriété réifiée’*** a été introduite pour permettre d'ajouter des assertions sur toutes les propriétés de l’ontologie qui correspondent aux attributs des entités du code RDA-FR. Par exemple, il est possible d’indiquer un niveau de fiabilité, ou une source pour un lieu de naissance d’une personne. Elle permet aussi de donner, à la propriété en question, une valeur textuelle ou une URI. Chaque propriété de ce type est systématiquement réifiée par une classe dont l’URI est la même que celle de la propriété. Cette classe est déclarée comme une sous classe de la classe P100008 *‘a une propriété réifiée’* :
+* Pour rappel, toute classe de l’ontologie RDA-FR est déclarée comme sous-classe de la classe racine **_Entité RDA-FR_**. Les propriétés de cette classe, en vertu du principe d’héritage, s’appliquent à toutes les sous-classes de l’ontologie, qu’il s’agisse des classes correspondant aux entités bibliographiques, que de celles ajoutées pour les besoins fonctionnels de l’ontologie RDA-FR, ou encore des classes ajoutées pour permettre une structuration fine et précise des données.
+* Les vocabulaires contrôlés dans l’ontologie RDA-FR relèvent de la classe **_[skos:ConceptScheme](http://www.w3.org/2004/02/skos/core#ConceptScheme)_**. Ils correspondent aux référentiels associés aux attributs des entités du code RDA-FR.
 
-  Exemple de réification de l’attribut *“a pour lieu de naissance de la personne”*
-![](https://user-images.githubusercontent.com/51800062/215849996-0a586184-0635-4a11-bee0-5fc292bd8ab9.jpg "Exemple de réification de l’attribut “a pour lieu de naissance de la personne”")
 
-- la classe P100001r ***'a une relation avec [dans la relation]’*** a été introduite pour permettre d’ajouter des assertions sur toutes les propriétés qui expriment une relation entre des instances de deux classes de l’ontologie (et qui, de fait, correspondent aux relations entre instances d’entités du code RDA-FR). Elle permet par exemple de donner des précisions (source, période, etc.) sur une relation de type *“a pour créateur / créateur de”* entre une oeuvre et une personne.
-Chaque propriété de ce type est systématiquement réifiée par une classe dont l’URI est la même que celle de la propriété. Cette classe est déclarée comme une sous classe de la classe P100001r *'a une relation avec [dans la relation]’*.
+    **Principe de réification**
 
-  Font exception de cette règle les relations dites fondamentales du modèle IFLA LRM entre les classes Oeuvre, Expression, Manifestation et Item.
 
-  Exemple de réification de la relation *“a pour créateur / créateur de”*
-![](https://user-images.githubusercontent.com/51800062/215851006-1a5e66c8-ec3c-4ac5-ac69-75c8c73b1955.jpg "Exemple de réification de la relation “a pour créateur / créateur de”")
+    Pour permettre l’ajout d’assertions sur les propriétés, le mécanisme de la réification systématique des propriétés en utilisant le même URI pour la propriété et sa réification a été implémenté dans l’ontologie RDA-FR. Ce mécanisme est basé sur le standard [ETSI GS CIM 006 V1.1.1 (2019 07)](https://drive.google.com/open?id=1EH-WjUL-2vwkze3JAM9xtc_l4czbSpIN). Pour cela deux classes sont créées :
 
-##### Gestion des règles et des contraintes
+* la classe P100008 **_‘a une propriété réifiée’_** a été introduite pour permettre d’ajouter des assertions sur toutes les propriétés de l’ontologie qui correspondent aux attributs des entités du code RDA-FR. Par exemple, il est possible d’indiquer un niveau de fiabilité, ou une source pour un lieu de naissance d’une personne. Elle permet aussi de donner, à la propriété en question, une valeur textuelle ou une URI. Chaque propriété de ce type est systématiquement réifiée par une classe dont l’URI est la même que celle de la propriété. Cette classe est déclarée comme une sous classe de la classe P100008 _‘a une propriété réifiée’_ :
 
-A l’ontologie RDA-FR sont associés des règles et des contraintes d’utilisation de ses classes et propriétés dans la pratique, permettant ainsi d’assurer l’implémentation de l’ontologie conforme au code RDA-FR. Il est à noter que plusieurs de ces règles et contraintes s’ajoutent aux instructions déjà incluses dans le code RDA-FR. Elles relèvent des instructions pour l’implémentation du code dans la gestion informatisée des données. En font partie des règles relatives au champ d’application d’une propriété, à la répétabilité, au caractère obligatoire ou non, au caractère confidentiel ou non, au type d’information attendu, etc. 
-Ces règles et contraintes sont exprimées et gérées séparément de l’ontologie RDA-FR, en langage SHACL [(Shapes Constraint Language)](https://www.w3.org/TR/shacl/). Il s’agit d’un standard du W3C spécialement conçu pour la validation des graphes RDF de données, créées, dans notre cas, avec l’ontologie RDA-FR, dans le respect des règles et contraintes fixées pour cette ontologie. 
+Exemple de réification de l’attribut _“a pour lieu de naissance de la personne”_ 
+![alt_text](images/image3.jpg "image_tooltip")
 
-#### Modalités techniques de publication de l’ontologie RDA-FR
+* la classe P100001r **_‘a une relation avec [dans la relation]’_** a été introduite pour permettre d’ajouter des assertions sur toutes les propriétés qui expriment une relation entre des instances de deux classes de l’ontologie (et qui, de fait, correspondent aux relations entre instances d’entités du code RDA-FR). Elle permet par exemple de donner des précisions (source, période, etc.) sur une relation de type _“a pour créateur / créateur de”_ entre une oeuvre et une personne. Chaque propriété de ce type est systématiquement réifiée par une classe dont l’URI est la même que celle de la propriété. Cette classe est déclarée comme une sous classe de la classe P100001r _‘a une relation avec [dans la relation]’_. \
+Font exception de cette règle les relations dites fondamentales du modèle IFLA LRM entre les classes Oeuvre, Expression, Manifestation et Item.
 
-- La version HTML du profil d’application RDA-FR est publiée ici : [https://rdafr.fr/profil-application/](/profil-application/)
-- La version SHACL du profil d’application (au format turtle) est publiée ici : [https://rdafr.fr/profil-application/rdafr-shacl.ttl](/profil-application/rdafr-shacl.ttl)
-- Une version HTML et OWL de l’ontologie seront publiées ultérieurement.
+Exemple de réification de la relation _“a pour créateur / créateur de”_ 
+![alt_text](images/image4.jpg "image_tooltip")
 
-L'ensemble de l'ontologie est géré depuis le compte GitHub du programme Transition bibliographique : [https://github.com/transition-bibliographique/ontologie-rda-fr](https://github.com/transition-bibliographique/ontologie-rda-fr). 
+**Principe de déclaration des propriétés, dites génériques, applicables à plusieurs entités**
 
-#### Contributeurs associés à ce projet
+Dans le code RDA-FR il existe des propriétés (relations ou attributs du code RDA-FR) qui peuvent être établies entre plusieurs entités. 
 
-- BnF : Anila Angjeli, Vincent Boulet, Etienne Cavalié, Françoise Leresche
-- Abes : Benjamin Bober, Mathis Eon, Stéphane Gully, Laure Jestaz, Héloïse Lecomte
-- La conception de cette ontologie a bénéficié de l’expertise et des compétences de Jean Delahousse.
+* Dans **le code RDA-FR**, elles sont déclarées expressément au niveau précis de chacune des entités auxquelles elles s’appliquent. Par exemple, on trouvera la relation “_collabore avec_” déclarée à la fois, entre deux personnes, entre deux collectivités, entre une personne et une collectivité, etc. 
+* Dans **l’ontologie RDA-FR** (en OWL) [<span style="text-decoration:underline;">mettre le lien lorsqu’on l’aura]</span>, pour ces types de propriété, le choix a été fait de déclarer seulement une propriété générique au niveau de la classe parente de ces classes (niveau le plus haut pertinent), en appliquant le principe d'héritage. 
+* Dans **[le profil d’application de l’ontologie RDA-FR](https://rdafr.fr/profil-application/)**, ces propriétés sont déclarées non seulement au niveau générique, mais aussi au niveau précis de chacune des sous-classes auxquelles elles s’appliquent. A noter qu’à ce niveau spécifique la propriété conserve le même URI et le même libellé que cette même propriété déclarée au niveau générique. Le profil d’application (SHACL) offre la possibilité de décrire les règles métier du code RDA-FR, avec, notamment les possibilités suivantes au niveau de chaque classe : 
+* lorsque, **dans l’ontologie RDA-FR**, une propriété est déclarée  au niveau générique d’une super-classe (ex.: Agent), mais que son application n’est pas pertinente pour une de ses sous-classes (ex.: Famille), dans le profil d’application de l’ontologie RDA-FR, cette propriété n’est simplement pas reprise au niveau de la sous-classe en question (la sous-classe Famille, le cas échéant). 
+* **dans le profil d’application de l’ontologie RDA-FR**, pour toutes ces propriétés génériques, il est possible de donner leur contexte d’application précis dans le cadre de la sous-classe précise, en donnant une définition contextuelle et en y associant des règles spécifiques lorsqu’il y a lieu, etc.
 
-Pour toute question sur cette publication merci d’écrire à [ontologie-rdafr@abes.fr](ontologie-rdafr@abes.fr) 
+    Dans l’exemple de la propriété “_collabore avec_”, celle-ci est déclarée comme propriété de la classe Agent. Elle est ensuite reprise, dans le profil d’application (avec le même URI et libellé), au niveau des sous-classes Personne, Collectivité, Famille (normalement il faut l’ajouter aussi au niveau de la classe intermédiaire Agent collectif qui est la super-classe de Collectivité,  Famille et Groupe informel, n’est-ce pas ?) partout où elle est pertinente avec, si besoin, des précisions d’application contextuelles.
+
+## L’ontologie RDA-FR en OWL et son profil d’application
+
+Le choix a été fait de publier le modèle de données RDA-FR sous la forme d’une ontologie (OWL) et d’un profil d’application (SHACL). 
+
+* **L’ontologie RDA-FR** modélise en classes et propriétés l’univers du discours couvert  par le code RDA-FR, elle est exprimée en langage [OWL](https://www.w3.org/OWL/) (Web Ontology Language).
+* **Le profil d’application RDA-FR** définit les règles et contraintes pour produire et valider les données RDF du graphe des données. Le profil d’application est exprimé en langage [SHACL](https://www.w3.org/TR/shacl/) (Shapes Constraint Language). Il s’agit d’un standard du W3C spécialement conçu pour la validation des graphes RDF de données, créées, dans notre cas, avec l’ontologie RDA-FR, dans le respect des règles et contraintes fixées pour cette ontologie. Dans le cadre de cette publication les règles SHACL expriment explicitement et de manière systématique les règles et contraintes génériques inhérentes au code RDA-FR, qu’elles soient explicitement ou implicitement formulées dans le code. Ces règles peuvent être des contraintes sur les cardinalités des propriétés, sur l’utilisation d’un vocabulaire contrôlé spécifique pour une propriété, etc.
+
+Cette dissociation a pour avantages : 
+
+* de disposer de** l’ontologie RDA-FR en OWL [mettre lien]**, porteuse de la structure de base qui exprime l’univers du discours couvert par le code RDA-FR ;
+* de mettre à disposition **[le profil d’application de l’ontologie RDA-FR](https://rdafr.fr/profil-application/)**, qui intègre les règles et les contraintes des données, gérées en langage SHACL, plus riches que celles contenues dans l’ontologie car elles permettent d’indiquer l’utilisation ou non d’une propriété dans une sous classe, et des règles spécifiques d’utilisation ;
+* de pouvoir adapter et enrichir ces règles sans modifier l’ontologie de base;
+* d’exécuter les règles SHACL sur les instances du graphe de connaissance pour vérifier que les données sont cohérentes et conformes à l'ontologie.
+
+### Gestion des règles et des contraintes
+
+A l’ontologie RDA-FR sont associés des règles et des contraintes d’utilisation de ses classes et propriétés dans la pratique, permettant ainsi d’assurer l’implémentation de l’ontologie conforme au code RDA-FR. Il est à noter que plusieurs de ces règles et contraintes s’ajoutent aux instructions déjà incluses dans le code RDA-FR. Elles relèvent des instructions pour l’implémentation du code dans la gestion informatisée des données. En font partie des règles relatives au champ d’application d’une propriété, à la répétabilité, au caractère obligatoire ou non, au caractère confidentiel ou non, au type d’information attendu, etc. Ces règles et contraintes sont exprimées et gérées séparément de l’ontologie RDA-FR, en langage SHACL [(Shapes Constraint Language)](https://www.w3.org/TR/shacl/). Il s’agit d’un standard du W3C spécialement conçu pour la validation des graphes RDF de données, créées, dans notre cas, avec l’ontologie RDA-FR, dans le respect des règles et contraintes fixées pour cette ontologie.
+
+## Déclaration de propriétés relevant des chapitres non publiés du code RDA-FR
+
+Il est à souligner que la section 9 du code RDA-FR, qui traite des relations entre agents, est toujours en cours de rédaction et non diffusée. Cependant, l’état d’avancement des travaux permet d’ores et déjà de disposer des listes fournies de relations entre agents. Une mise en cohérence de l’ontologie RDA-FR avec la section 9 sera effectuée au moment de la publication de cette dernière.
+
+## Modalités techniques de publication de l’ontologie RDA-FR
+
+* La version HTML du profil d’application RDA-FR est publiée ici : [https://rdafr.fr/profil-application/](https://rdafr.fr/profil-application/)
+* La version SHACL du profil d’application (au format turtle) est publiée ici : [https://rdafr.fr/profil-application/rdafr-shacl.ttl](https://rdafr.fr/profil-application/rdafr-shacl.ttl)
+* La version HTML et OWL de l’ontologie [lien à venir].
+
+L’ensemble de l’ontologie est géré depuis le compte GitHub du programme Transition bibliographique : [https://github.com/transition-bibliographique/ontologie-rda-fr](https://github.com/transition-bibliographique/ontologie-rda-fr).
+
+## Historique des versions
+
+*  [v.0.0.1 (janvier 2023) - première publication](https://rdafr.fr/ontologie-rdafr/release-notes.html#v.0.0.1)
+*  [v.0.1.0 (mai 2023)](https://rdafr.fr/ontologie-rdafr/release-notes.html#v.0.1.0)
+
+## Contributeurs associés à ce projet
+
+* BnF : Anila Angjeli, Vincent Boulet, Etienne Cavalié, Françoise Leresche
+* Abes : Benjamin Bober, Mathis Eon, Stéphane Gully, Laure Jestaz, Héloïse Lecomte
+* La conception de cette ontologie a bénéficié de l’expertise et des compétences de Jean Delahousse.
+
+Pour toute question sur cette publication merci d’écrire à [ontologie-rdafr@abes.fr](mailto:ontologie-rdafr@abes.fr)

--- a/siteweb/release-notes.md
+++ b/siteweb/release-notes.md
@@ -1,6 +1,6 @@
 # Ontologie RDA-FR - Historique des versions
 
-## v.0.1.0, mai 2023 
+## v.0.1.0, mai 2023 {#v0.1.0}
 
 Version, toujours qualifiée comme beta, reste partielle, et le caractère évolutif de l’ontologie d’une version à l’autre toujours valable. Apports de cette version : 
 
@@ -28,7 +28,7 @@ l’explication sur le choix de dissocier l’ontologie RDA-FR (en OWL) de son p
     * cette page portera aussi la mention du numéro de la dernière version de publication de l’ontologie, le numéro de cette version étant V 0.1.0. 
     * les nouveautés d’une version à l’autre sont retracées dans la page distincte Historique des versions https://rdafr.fr/release-notes à laquelle on accède aussi depuis la section Historique des versions de la page https://rdafr.fr.
 
-## v.0.0.1, janvier 2023 - première publication
+## v.0.0.1, janvier 2023 - première publication {#v0.0.1}
 
 La première publication de l’ontologie RDA-FR comprend :
 
@@ -38,5 +38,3 @@ La première publication de l’ontologie RDA-FR comprend :
   * le texte explicatif sur les choix architecturaux et les mécanismes fonctionnels de gestion de cette ontologie et de son profil d’application (texte évolutif au fil des versions) ;
 * la publication du profil d’application de l’ontologie RDA-FR, relatif aux classes : Agent, Agent collectif, Groupe informel, Personne, Identité publique ;
 * l’information sur les modalités techniques de publication de l’ontologie RDA-FR, avec accès aux pages html concernées et le compte GitHub où l’ensemble de l’ontologie est géré.
-
-

--- a/siteweb/release-notes.md
+++ b/siteweb/release-notes.md
@@ -1,16 +1,5 @@
 # Ontologie RDA-FR - Historique des versions
 
-## v.0.0.1, janvier 2023 - première publication
-
-La première publication de l’ontologie RDA-FR comprend :
-
-* une introduction sur : 
-  * le cadre de l’élaboration de l’ontologie RDA-FR et ses objectifs ;  
-  * le choix des deux agences bibliographiques, la BnF et l’Abes, de publier l’ontologie RDA-FR progressivement, par blocs de classes cohérents, au fur et à mesure de son élaboration ;
-  * le texte explicatif sur les choix architecturaux et les mécanismes fonctionnels de gestion de cette ontologie et de son profil d’application (texte évolutif au fil des versions) ;
-* la publication du profil d’application de l’ontologie RDA-FR, relatif aux classes : Agent, Agent collectif, Groupe informel, Personne, Identité publique ;
-* l’information sur les modalités techniques de publication de l’ontologie RDA-FR, avec accès aux pages html concernées et le compte GitHub où l’ensemble de l’ontologie est géré.
-
 ## v.0.1.0, mai 2023 
 
 Version, toujours qualifiée comme beta, reste partielle, et le caractère évolutif de l’ontologie d’une version à l’autre toujours valable. Apports de cette version : 
@@ -38,4 +27,16 @@ l’explication sur le choix de dissocier l’ontologie RDA-FR (en OWL) de son p
     * les informations sur les modalités techniques de publication de l’ontologie RDA-FR
     * cette page portera aussi la mention du numéro de la dernière version de publication de l’ontologie, le numéro de cette version étant V 0.1.0. 
     * les nouveautés d’une version à l’autre sont retracées dans la page distincte Historique des versions https://rdafr.fr/release-notes à laquelle on accède aussi depuis la section Historique des versions de la page https://rdafr.fr.
+
+## v.0.0.1, janvier 2023 - première publication
+
+La première publication de l’ontologie RDA-FR comprend :
+
+* une introduction sur : 
+  * le cadre de l’élaboration de l’ontologie RDA-FR et ses objectifs ;  
+  * le choix des deux agences bibliographiques, la BnF et l’Abes, de publier l’ontologie RDA-FR progressivement, par blocs de classes cohérents, au fur et à mesure de son élaboration ;
+  * le texte explicatif sur les choix architecturaux et les mécanismes fonctionnels de gestion de cette ontologie et de son profil d’application (texte évolutif au fil des versions) ;
+* la publication du profil d’application de l’ontologie RDA-FR, relatif aux classes : Agent, Agent collectif, Groupe informel, Personne, Identité publique ;
+* l’information sur les modalités techniques de publication de l’ontologie RDA-FR, avec accès aux pages html concernées et le compte GitHub où l’ensemble de l’ontologie est géré.
+
 


### PR DESCRIPTION
Cette PR modifie la façon de construire le conteneur Docker, en déportant toute la logique de génération dans l'action Github. 

J'ai opté pour cette modification suite à l'utilisation de Widoco lors de la génération de la documentation HTML de l'ontologie. Windoco ajoutait de nouvelles dépendances inutiles lors du build du conteneur ngnix : java, widoco en plus de pandoc ; et surtout pas mal de code qui rendait le Docker file confus.

J'ai centralisé la partie traitement de données, génération HTML dans une action spécifique. Ce qui permet de simplifier énormément le Dockerfile, et rend plus lisible les traitements :

![image](https://user-images.githubusercontent.com/60341438/234581786-ea35e36c-6ee2-4588-aa2d-d3333907e84c.png)

# Architecture :

Toute la partie génération est centralisée dans une GitHub action spécifique : prepare-release.yml. Cette action est responsable de la génération de la documentation, du profil d'application et du site web (avec les release notes). Le résultat de la génération est conservé dans un artifact GitHub nommé build. L'utilisation d'un artifact permet de partager des données entre jobs.

L'action `prepare-release` a un déclencheur workflow_call, qui lui permet d'être appelée par d'autre workflow. Dans notre cas : build-test-pubtodockerhub.yml

![image](https://user-images.githubusercontent.com/60341438/234582131-2ee7d615-008e-4b3c-abe1-b6ed6b96dbc7.png)

## __Workflow :__

* Au déclenchement de build-test-pubtodockerhub l'action `prepare-release` est déclenchée.
* build-test-pubtodockerhub récupère le résultat de `prepare-release` en téléchargeant l'artifact build. 
* La génération de l'image Docker poursuit son cours normal

Dans le workflow `build-test-pubtodockerhub` le job `build-test-pubtodockerhub` dépend du job `prepare-release` (`needs: prepare-release `), pour garantir que la génération soit finalisée avant de build le conteneur docker.

# TODO :

* Compléter les liens vers l'ontologie au format HTML, en l'état il s'agit de https://rdafr.fr/ontologie/index.html
* Vérifier que les liens entre la page d’accueil et les release notes renvoient bien vers leurs sections respectives

@kerphi le processus n'est pas testé jusqu'au bout. J'ai testé le workflow sur un fork du dépôt : l'enchainement des workflows et la génération semblent fonctionner correctement, mais en l'absence des clés d'API le job fini par échouer sur la partie deploy sur dockerhub (cf capture d'écran ci-dessus). Je n'ai donc pas vu ce que ça donne sur l'interface de test de rdafr.fr. Je n'ai pas voulu merger compte tenu de la nature des modifications.