### PR TITLE
Fix: ajout d'un titre de page pour les vocabulaires contrôlés

### DIFF
--- a/siteweb/.xslt/liste-vocabulaires.xsl
+++ b/siteweb/.xslt/liste-vocabulaires.xsl
@@ -12,7 +12,8 @@
     <xsl:strip-space elements="*"/>
     
     <xsl:template match="/">
-       <xsl:text>&#10;&#10;</xsl:text>
+       <xsl:text>---&#10;pagetitle: Ontologie RDA-FR - Vocabulaires contrôlés&#10;---&#10;</xsl:text>
+       <xsl:text>&#10;</xsl:text>
        <xsl:comment>Ce fichier est généré automatiquement. Il ne doit pas être édité manuellement.</xsl:comment> 
        <xsl:text>&#10;&#10;</xsl:text>                                                                              
        <xsl:call-template name="liste-vocab"/>


### PR DESCRIPTION
Il est nécessaire de modifier le XSLT pour rajouter les métadonnées `pagetitle` dans le fichier qui contient la liste des vocabulaire, car pandoc ne prend en compte que les métadonnées de la dernière page lorsque deux pages sont concaténées ([voir le Dockerfile](https://github.com/transition-bibliographique/ontologie-rda-fr/blob/main/Dockerfile#L53-L61)).

